### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A scalable knowledge graph implementation for Model Context Protocol (MCP) using Elasticsearch as the backend. This implementation is designed to replace the previous JSON file-based approach with a more scalable, performant solution.
 
+<a href="https://glama.ai/mcp/servers/h9w4cyfdqx">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/h9w4cyfdqx/badge" alt="Elasticsearch Knowledge Graph for MCP server" />
+</a>
+
 ## Key Features
 
 - **Scalable Storage**: Elasticsearch provides distributed, scalable storage for knowledge graph entities and relations


### PR DESCRIPTION
This PR adds a badge for the [Elasticsearch Knowledge Graph for MCP](https://glama.ai/mcp/servers/h9w4cyfdqx) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/h9w4cyfdqx">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/h9w4cyfdqx/badge" alt="Elasticsearch Knowledge Graph for MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.